### PR TITLE
model was named image so migration file failed

### DIFF
--- a/src/auto_populate_database.py
+++ b/src/auto_populate_database.py
@@ -48,7 +48,7 @@ def populate_db(apps, schema_editor):
     host_table = apps.get_model('parking', 'Host')
     location_table = apps.get_model('parking', 'Location')
     transaction_table = apps.get_model('parking', 'Transactions')
-    image_table = apps.get_model('parking', 'Image')
+    image_table = apps.get_model('parking', 'LocationImage')
 
     standard_spot = parking_table(
         name="Standard Spot",


### PR DESCRIPTION
it was being referred to as the Image model, which borked the migration, but I think someone just renamed the model and forgot to adjust the populate_db migration. 