### PR TITLE
moved the requirements file and removed the python==3.9 line

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 django==3.1.5
-python==3.9
 Pillow==8.0


### PR DESCRIPTION
Moved the requirements file to the  base dir and removed "python==3.9"